### PR TITLE
Custom fill_value support

### DIFF
--- a/src/variable.rs
+++ b/src/variable.rs
@@ -50,6 +50,7 @@ pub trait Numeric {
     /// put a SLICE of values into a netCDF variable at the given index
     fn put_values_at(variable: &mut Variable, indices: &[usize], slice_len: &[usize], values: &[Self]) -> Result<(), String>
         where Self: Sized;
+    /// Returns `self` as a C (void *) pointer
     fn as_void_ptr(&self) -> *const libc::c_void;
 }
 
@@ -480,6 +481,7 @@ impl Variable {
             return Err(NC_ERRORS.get(&err).unwrap().clone());
         }
         let (grp_id, var_id) = (self.grp_id, self.id);
+        self.attributes.clear();
         init_attributes(&mut self.attributes, grp_id, var_id, natts);
         Ok(())
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -670,3 +670,25 @@ fn put_values() {
         values
     );
 }
+
+#[test]
+/// Test setting a fill value when creating a Variable
+fn set_fill_value() {
+    let f = test_file_new("fill_value.nc");
+    let dim_name = "some_dimension";
+    let var_name = "some_variable";
+    let fill_value = -2. as f32;
+
+    let mut file_w = netcdf::create(&f).unwrap();
+    file_w.root.add_dimension(dim_name, 3).unwrap();
+    file_w.root.add_variable_with_fill_value(
+        var_name,
+        &vec![dim_name.into()],
+        &vec![1. as f32, 2. as f32, 3. as f32],
+        fill_value
+    ).unwrap();
+    let var =  file_w.root.variables.get(var_name).unwrap();
+    let attr = var.attributes.get("_FillValue").unwrap().get_float(false).unwrap();
+    // compare requested fill_value and attribute _FillValue
+    assert_eq!(fill_value, attr);
+}


### PR DESCRIPTION
Hello,

I've implemented the support for custom **_FillValue** definition when creating a new variable.
This can only be done after the variable creation and before "filling" it with values, that's why I had to
implement a [add_variables](https://github.com/evomassiny/rust-netcdf/blob/cca2a722059a971eca6f71e61145cea49bf50baa/src/group.rs#L163) -like method called [add_variable_with_fill_value](https://github.com/evomassiny/rust-netcdf/blob/cca2a722059a971eca6f71e61145cea49bf50baa/src/group.rs#L173).

You can see a usage example in the related [unit test](https://github.com/evomassiny/rust-netcdf/blob/cca2a722059a971eca6f71e61145cea49bf50baa/tests/lib.rs#L676).

Also, could you bump the crate version number (for the crates.io repository) ?
It should trigger another  build for the cargo documentation, which hopefully should succeed :)

Thanks for your time.