### PR TITLE
limit rebuilds of netcdf-sys

### DIFF
--- a/netcdf-sys/build.rs
+++ b/netcdf-sys/build.rs
@@ -1,3 +1,4 @@
 fn main() {
     println!("cargo:rustc-link-lib=netcdf");
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
adds a dummy rerun-if-changed so the build does not run when spurious files are added/removed in this crate

See also #21