### PR TITLE
Ownership

### DIFF
--- a/examples/ncdump.rs
+++ b/examples/ncdump.rs
@@ -29,7 +29,8 @@ fn run(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
 fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error>> {
     println!("Group: {}", g.name()?);
     println!("Dimensions:");
-    for d in g.dimensions() {
+    for d in g.dimensions()? {
+        let d = d?;
         if d.is_unlimited() {
             println!("\t{} : Unlimited ({})", d.name()?, d.len());
         } else {
@@ -37,7 +38,8 @@ fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error
         }
     }
     println!("Variables:");
-    for v in g.variables() {
+    for v in g.variables()? {
+        let v = v?;
         print!("\t{}", v.name()?);
         print!("(");
         for d in v.dimensions() {
@@ -54,7 +56,7 @@ fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error
         let a = a?;
         println!("\t\t{} = {:?}", a.name().unwrap(), a.value()?);
     }
-    for g in g.groups() {
+    for g in g.groups()? {
         println!();
         print_group(&g)?;
     }

--- a/examples/ncdump.rs
+++ b/examples/ncdump.rs
@@ -48,13 +48,13 @@ fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error
         println!(")");
         for a in v.attributes()? {
             let a = a?;
-            println!("\t\t{} = {:?}", a.name().unwrap(), a.value()?);
+            println!("\t\t{} = {:?}", a.name()?, a.value()?);
         }
     }
     println!("Attributes:");
     for a in g.attributes()? {
         let a = a?;
-        println!("\t\t{} = {:?}", a.name().unwrap(), a.value()?);
+        println!("\t\t{} = {:?}", a.name()?, a.value()?);
     }
     for g in g.groups()? {
         println!();

--- a/examples/ncdump.rs
+++ b/examples/ncdump.rs
@@ -22,7 +22,7 @@ fn main() {
 fn run(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     let file = netcdf::open(path)?;
 
-    println!("{}", file.name());
+    println!("{}", file.path()?);
     print_group(&file)
 }
 

--- a/examples/ncdump.rs
+++ b/examples/ncdump.rs
@@ -23,7 +23,7 @@ fn run(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     let file = netcdf::open(path)?;
 
     println!("{}", file.path()?);
-    print_group(&file)
+    print_group(&file.root())
 }
 
 fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error>> {
@@ -56,7 +56,7 @@ fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error
     }
     for g in g.groups() {
         println!();
-        print_group(g)?;
+        print_group(&g)?;
     }
 
     Ok(())

--- a/examples/ncdump.rs
+++ b/examples/ncdump.rs
@@ -31,9 +31,9 @@ fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error
     println!("Dimensions:");
     for d in g.dimensions() {
         if d.is_unlimited() {
-            println!("\t{} : Unlimited ({})", d.name(), d.len());
+            println!("\t{} : Unlimited ({})", d.name()?, d.len());
         } else {
-            println!("\t{} : ({})", d.name(), d.len());
+            println!("\t{} : ({})", d.name()?, d.len());
         }
     }
     println!("Variables:");
@@ -41,7 +41,7 @@ fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error
         print!("\t{}", v.name()?);
         print!("(");
         for d in v.dimensions() {
-            print!(" {} ", d.name());
+            print!(" {} ", d.name()?);
         }
         println!(")");
         for a in v.attributes()? {

--- a/examples/ncdump.rs
+++ b/examples/ncdump.rs
@@ -27,7 +27,7 @@ fn run(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Group: {}", g.name());
+    println!("Group: {}", g.name()?);
     println!("Dimensions:");
     for d in g.dimensions() {
         if d.is_unlimited() {

--- a/examples/ncdump.rs
+++ b/examples/ncdump.rs
@@ -38,7 +38,7 @@ fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error
     }
     println!("Variables:");
     for v in g.variables() {
-        print!("\t{}", v.name());
+        print!("\t{}", v.name()?);
         print!("(");
         for d in v.dimensions() {
             print!(" {} ", d.name());

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -469,7 +469,6 @@ impl<'a> Attribute<'a> {
             attname
         };
 
-        let _l = LOCK.lock().unwrap();
         error::checked(unsafe {
             match val {
                 AttrValue::Uchar(x) => {

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -469,14 +469,7 @@ impl<'a> Attribute<'a> {
         name: &str,
         val: AttrValue,
     ) -> error::Result<Self> {
-        let cname = {
-            if name.len() > NC_MAX_NAME as usize {
-                return Err(error::Error::Netcdf(NC_EMAXNAME));
-            }
-            let mut attname = [0_u8; NC_MAX_NAME as usize + 1];
-            attname[..name.len()].copy_from_slice(name.as_bytes());
-            attname
-        };
+        let cname = super::utils::short_name_to_bytes(name)?;
 
         error::checked(unsafe {
             match val {

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -75,18 +75,18 @@ impl<'g> Dimension<'g> {
 
 pub(crate) fn from_name_toid<'f>(loc: nc_type, name: &str) -> error::Result<nc_type> {
     let mut dimid = 0;
-    let cname = std::ffi::CString::new(name).unwrap();
+    let cname = super::utils::short_name_to_bytes(name)?;
     unsafe {
-        error::checked(nc_inq_dimid(loc, cname.as_ptr(), &mut dimid))?;
+        error::checked(nc_inq_dimid(loc, cname.as_ptr() as *const _, &mut dimid))?;
     }
     Ok(dimid)
 }
 
 pub(crate) fn from_name<'f>(loc: nc_type, name: &str) -> error::Result<Dimension<'f>> {
     let mut dimid = 0;
-    let cname = std::ffi::CString::new(name).unwrap();
+    let cname = super::utils::short_name_to_bytes(name)?;
     unsafe {
-        error::checked(nc_inq_dimid(loc, cname.as_ptr(), &mut dimid))?;
+        error::checked(nc_inq_dimid(loc, cname.as_ptr() as *const _, &mut dimid))?;
     }
     let mut dimlen = 0;
     unsafe {
@@ -167,9 +167,9 @@ pub(crate) fn dimension_from_name<'f>(
     ncid: nc_type,
     name: &str,
 ) -> error::Result<Option<Dimension<'f>>> {
-    let cname = std::ffi::CString::new(name).unwrap();
+    let cname = super::utils::short_name_to_bytes(name)?;
     let mut dimid = 0;
-    let e = unsafe { nc_inq_dimid(ncid, cname.as_ptr(), &mut dimid) };
+    let e = unsafe { nc_inq_dimid(ncid, cname.as_ptr() as *const _, &mut dimid) };
     if e == NC_ENOTFOUND {
         return Ok(None);
     } else {
@@ -191,10 +191,15 @@ pub(crate) fn add_dimension_at<'f>(
     name: &str,
     len: usize,
 ) -> error::Result<Dimension<'f>> {
-    let cname = std::ffi::CString::new(name).unwrap();
+    let cname = super::utils::short_name_to_bytes(name)?;
     let mut dimid = 0;
     unsafe {
-        error::checked(nc_def_dim(ncid, cname.as_ptr(), len, &mut dimid))?;
+        error::checked(nc_def_dim(
+            ncid,
+            cname.as_ptr() as *const _,
+            len,
+            &mut dimid,
+        ))?;
     }
     Ok(Dimension {
         len: core::num::NonZeroUsize::new(dimid as _),

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -33,6 +33,7 @@ impl<'g> Dimension<'g> {
         } else {
             let mut len = 0;
             let err = unsafe {
+                // Must lock in case other variables adds to the dimension length
                 let _l = LOCK.lock().unwrap();
                 error::checked(nc_inq_dimlen(self.id.ncid, self.id.dimid, &mut len))
             };

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -25,8 +25,7 @@ pub struct Identifier {
 
 #[allow(clippy::len_without_is_empty)]
 impl<'g> Dimension<'g> {
-    /// Get current length of the dimensions, which is
-    /// the product of all dimensions in the variable
+    /// Get current length of this dimension
     pub fn len(&self) -> usize {
         if let Some(x) = self.len {
             x.get()
@@ -67,7 +66,8 @@ impl<'g> Dimension<'g> {
         Ok(String::from_utf8(name)?)
     }
 
-    /// Grabs a unique identifier for this dimension
+    /// Grabs the unique identifier for this dimension, which
+    /// can be used in `add_variable_from_identifiers`
     pub fn identifier(&self) -> Identifier {
         self.id
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,7 +81,10 @@ impl From<String> for Error {
 
 impl From<nc_type> for Error {
     fn from(nc: nc_type) -> Self {
-        if nc == netcdf_sys::NC_EEXIST || nc == netcdf_sys::NC_EATTEXISTS || nc == netcdf_sys::NC_ENAMEINUSE {
+        if nc == netcdf_sys::NC_EEXIST
+            || nc == netcdf_sys::NC_EATTEXISTS
+            || nc == netcdf_sys::NC_ENAMEINUSE
+        {
             Self::AlreadyExists
         } else {
             Self::Netcdf(nc)

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     /// Requested a zero slice
     ZeroSlice,
     /// Zero stride or matched with length != 1
-    StrideError,
+    Stride,
     /// Supplied the wrong type of parameter
     TypeMismatch,
     /// Does not know the type (probably library error...)
@@ -52,7 +52,7 @@ impl Error {
     /// Was the error due to ambiguity of the
     /// indices or lengths?
     pub fn is_ambigous(&self) -> bool {
-        if let Error::Ambiguous = self {
+        if let Self::Ambiguous = self {
             true
         } else {
             false
@@ -113,7 +113,7 @@ impl fmt::Display for Error {
             Self::IndexMismatch => write!(f, "requested index is bigger than the dimension length"),
             Self::SliceMismatch => write!(f, "requested slice is bigger than the dimension length"),
             Self::ZeroSlice => write!(f, "must request a slice length larger than zero"),
-            Self::StrideError => write!(f, "invalid strides"),
+            Self::Stride => write!(f, "invalid strides"),
             Self::BufferLen(has, need) => write!(
                 f,
                 "buffer size mismatch, has size {}, but needs size {}",

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,6 @@
 
 #![allow(clippy::similar_names)]
 use super::nc_type;
-use super::LOCK;
 use netcdf_sys::nc_strerror;
 use std::num::TryFromIntError;
 
@@ -125,7 +124,6 @@ impl fmt::Display for Error {
             Self::AlreadyExists => write!(f, "variable/group/dimension already exists"),
             Self::NotFound(x) => write!(f, "Could not find {}", x),
             Self::Netcdf(x) => {
-                let _l = LOCK.lock().unwrap();
                 let msg;
                 unsafe {
                     let cmsg = nc_strerror(*x);

--- a/src/file.rs
+++ b/src/file.rs
@@ -120,7 +120,7 @@ impl ReadOnlyFile {
             name
         };
 
-        String::from_utf8(name).map_err(|e| e.into())
+        Ok(String::from_utf8(name)?)
     }
 
     /// Main entrypoint for interacting with the netcdf file.

--- a/src/file.rs
+++ b/src/file.rs
@@ -218,40 +218,9 @@ impl ReadOnlyFile {
         })
     }
     pub fn dimensions<'g>(&'g self) -> impl Iterator<Item = Dimension<'g>> {
-        let mut ndims = 0;
-        unsafe {
-            error::checked(nc_inq_dimids(
-                self.ncid(),
-                &mut ndims,
-                std::ptr::null_mut(),
-                false as _,
-            ))
-            .unwrap();
-        }
-        let mut dimids = vec![0; ndims as _];
-        unsafe {
-            error::checked(nc_inq_dimids(
-                self.ncid(),
-                std::ptr::null_mut(),
-                dimids.as_mut_ptr(),
-                false as _,
-            ))
-            .unwrap();
-        }
-        dimids.into_iter().map(move |dimid| {
-            let mut dimlen = 0;
-            unsafe {
-                error::checked(nc_inq_dimlen(self.ncid(), dimid, &mut dimlen)).unwrap();
-            }
-            Dimension {
-                len: core::num::NonZeroUsize::new(dimlen),
-                id: Identifier {
-                    ncid: self.ncid(),
-                    dimid,
-                },
-                _group: PhantomData,
-            }
-        })
+        super::dimension::dimension_iterator(self.ncid())
+            .unwrap()
+            .map(|x| x.unwrap())
     }
     pub fn attribute<'f>(&'f self, name: &str) -> error::Result<Option<Attribute<'f>>> {
         if name.len() > NC_MAX_NAME as _ {

--- a/src/file.rs
+++ b/src/file.rs
@@ -28,7 +28,7 @@ impl Drop for File {
 }
 
 impl File {
-    /// Open a netCDF file in read only mode.
+    /// Open a `netCDF` file in read only mode.
     ///
     /// Consider using [`netcdf::open`] instead to open with
     /// a generic `Path` object, and ensure read-only on
@@ -94,6 +94,8 @@ impl File {
 }
 
 #[derive(Debug)]
+/// Read only accessible file
+#[allow(clippy::module_name_repetitions)]
 pub struct ReadOnlyFile(File);
 
 impl ReadOnlyFile {
@@ -124,7 +126,7 @@ impl ReadOnlyFile {
     }
 
     /// Main entrypoint for interacting with the netcdf file.
-    pub fn root<'f>(&'f self) -> Group<'f> {
+    pub fn root(&self) -> Group {
         Group {
             ncid: self.ncid(),
             _file: PhantomData,
@@ -182,6 +184,7 @@ impl ReadOnlyFile {
 
 /// Mutable access to file
 #[derive(Debug)]
+#[allow(clippy::module_name_repetitions)]
 pub struct MutableFile(ReadOnlyFile);
 
 impl std::ops::Deref for MutableFile {
@@ -193,7 +196,7 @@ impl std::ops::Deref for MutableFile {
 
 impl MutableFile {
     /// Mutable access to the root group
-    pub fn root_mut<'f>(&'f mut self) -> GroupMut<'f> {
+    pub fn root_mut(&mut self) -> GroupMut {
         GroupMut(self.root(), PhantomData)
     }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::similar_names)]
 use super::attribute::{AttrValue, Attribute};
-use super::dimension::{Dimension, Identifier};
+use super::dimension::{self, Dimension};
 use super::error;
 use super::group::{Group, GroupMut};
 use super::variable::{Numeric, Variable, VariableMut};
@@ -208,7 +208,7 @@ impl MutableFile {
     pub fn add_variable_from_identifiers<T>(
         &mut self,
         name: &str,
-        dims: &[super::dimension::Identifier],
+        dims: &[dimension::Identifier],
     ) -> error::Result<VariableMut>
     where
         T: Numeric,

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,24 +1,85 @@
 //! Open, create, and append netcdf files
 
 #![allow(clippy::similar_names)]
+use super::attribute::{AttrValue, Attribute};
+use super::dimension::{Dimension, Identifier};
 use super::error;
-use super::group::Group;
+use super::group::{Group, GroupMut};
+use super::variable::{Numeric, Variable, VariableMut};
 use super::LOCK;
 use netcdf_sys::*;
-use std::cell::UnsafeCell;
-use std::convert::TryInto;
 use std::ffi::CString;
+use std::marker::PhantomData;
 use std::path;
-use std::rc::Rc;
 
-/// Container for netcdf type
 #[derive(Debug)]
-pub struct File {
-    pub(crate) ncid: nc_type,
-    pub(crate) root: Rc<UnsafeCell<Group>>,
+pub(crate) struct File {
+    ncid: nc_type,
 }
 
 impl File {
+    fn open(path: &path::Path) -> error::Result<Self> {
+        let f = CString::new(path.to_str().unwrap()).unwrap();
+        let mut ncid: nc_type = -1;
+        unsafe {
+            let _l = LOCK.lock().unwrap();
+            error::checked(nc_open(f.as_ptr(), NC_NOWRITE, &mut ncid))?;
+        }
+        Ok(Self { ncid })
+    }
+
+    #[allow(clippy::doc_markdown)]
+    /// Open a netCDF file in append mode (read/write).
+    /// The file must already exist.
+    fn append(path: &path::Path) -> error::Result<Self> {
+        let f = CString::new(path.to_str().unwrap()).unwrap();
+        let mut ncid: nc_type = -1;
+        unsafe {
+            let _g = LOCK.lock().unwrap();
+            error::checked(nc_open(f.as_ptr(), NC_WRITE, &mut ncid))?;
+        }
+
+        Ok(Self { ncid })
+    }
+    #[allow(clippy::doc_markdown)]
+    /// Open a netCDF file in creation mode.
+    ///
+    /// Will overwrite existing file if any
+    pub(crate) fn create(path: &path::Path) -> error::Result<Self> {
+        let f = CString::new(path.to_str().unwrap()).unwrap();
+        let mut ncid: nc_type = -1;
+        unsafe {
+            let _g = LOCK.lock().unwrap();
+            error::checked(nc_create(f.as_ptr(), NC_NETCDF4 | NC_CLOBBER, &mut ncid))?;
+        }
+
+        Ok(Self { ncid })
+    }
+}
+
+impl Drop for File {
+    fn drop(&mut self) {
+        unsafe {
+            let _g = LOCK.lock().unwrap();
+            // Can't really do much with an error here
+            let _err = error::checked(nc_close(self.ncid));
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ReadOnlyFile(File);
+
+impl ReadOnlyFile {
+    /// Open a netCDF file in read only mode.
+    ///
+    /// Consider using [`crate::open`] instead to open with
+    /// a generic `Path` object, and ensure read-only on
+    /// the `File`
+    pub(crate) fn open(path: &path::Path) -> error::Result<Self> {
+        let file = File::open(path)?;
+        Ok(Self(file))
+    }
     /// path used ot open/create the file
     ///
     /// #Errors
@@ -29,12 +90,12 @@ impl File {
         let name = {
             let mut pathlen = 0;
             unsafe {
-                error::checked(nc_inq_path(self.ncid, &mut pathlen, std::ptr::null_mut()))?;
+                error::checked(nc_inq_path(self.0.ncid, &mut pathlen, std::ptr::null_mut()))?;
             }
             let mut name = vec![0_u8; pathlen as _];
             unsafe {
                 error::checked(nc_inq_path(
-                    self.ncid,
+                    self.0.ncid,
                     std::ptr::null_mut(),
                     name.as_mut_ptr() as *mut _,
                 ))?;
@@ -45,123 +106,355 @@ impl File {
         String::from_utf8(name).map_err(|e| e.into())
     }
 
-    /// Main entrypoint for interacting with the netcdf file. Also accessible
-    /// through the `Deref` trait on `File`
-    pub fn root(&self) -> &Group {
-        unsafe { &*self.root.get() }
-    }
-
-    /// Mutable access to the root group
-    pub fn root_mut(&mut self) -> &mut Group {
-        unsafe { &mut *self.root.get() }
-    }
-}
-
-impl std::ops::Deref for File {
-    type Target = Group;
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.root.get() }
-    }
-}
-
-impl std::ops::DerefMut for File {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.root.get() }
-    }
-}
-
-impl File {
-    #[allow(clippy::doc_markdown)]
-    /// Open a netCDF file in read only mode.
-    ///
-    /// Consider using [`crate::open`] instead to open with
-    /// a generic `Path` object, and ensure read-only on
-    /// the `File`
-    pub fn open(path: &path::Path) -> error::Result<Self> {
-        let f = CString::new(path.to_str().unwrap()).unwrap();
-        let mut ncid: nc_type = -1;
-        unsafe {
-            let _g = LOCK.lock().unwrap();
-            error::checked(nc_open(f.as_ptr(), NC_NOWRITE, &mut ncid))?;
-        }
-
-        let root = parse_file(ncid)?;
-
-        Ok(Self { ncid, root })
-    }
-    #[allow(clippy::doc_markdown)]
-    /// Open a netCDF file in append mode (read/write).
-    /// The file must already exist.
-    pub fn append(path: &path::Path) -> error::Result<Self> {
-        let f = CString::new(path.to_str().unwrap()).unwrap();
-        let mut ncid: nc_type = -1;
-        unsafe {
-            let _g = LOCK.lock().unwrap();
-            error::checked(nc_open(f.as_ptr(), NC_WRITE, &mut ncid))?;
-        }
-
-        let root = parse_file(ncid)?;
-
-        Ok(Self { ncid, root })
-    }
-    #[allow(clippy::doc_markdown)]
-    /// Open a netCDF file in creation mode.
-    ///
-    /// Will overwrite existing file if any
-    pub fn create(path: &path::Path) -> error::Result<Self> {
-        let f = CString::new(path.to_str().unwrap()).unwrap();
-        let mut ncid: nc_type = -1;
-        unsafe {
-            let _g = LOCK.lock().unwrap();
-            error::checked(nc_create(f.as_ptr(), NC_NETCDF4 | NC_CLOBBER, &mut ncid))?;
-        }
-
-        let root = Rc::new(UnsafeCell::new(Group {
-            ncid,
+    /// Main entrypoint for interacting with the netcdf file.
+    pub fn root<'f>(&'f self) -> Group<'f> {
+        Group {
+            ncid: self.0.ncid,
             grpid: None,
-            variables: Vec::default(),
-            dimensions: Vec::default(),
-            groups: Vec::default(),
-            parent: None,
-            this: None,
-        }));
-        {
-            let rootref = Some(Rc::downgrade(&root));
-            let root = unsafe { &mut *root.get() };
-            root.this = rootref;
+            _file: PhantomData,
         }
-        Ok(Self { ncid, root })
     }
-}
 
-/// File that does not allow writing to it, enforced by
-/// borrow rules (can not get `mut File`)
-///
-/// `Deref`s to `File`, but does not provide mutable access,
-/// so the following code will not compile:
-/// ```compile_fail
-/// # fn main() -> netcdf::Result<()>{
-/// let file = netcdf::open("file.nc")?;
-/// file.add_dimension("somedim", 10)?;
-/// # }
-/// ```
-#[derive(Debug)]
-pub struct ReadOnlyFile {
-    file: File,
-}
+    pub fn variable<'g>(&'g self, name: &str) -> error::Result<Option<Variable<'g, 'g>>> {
+        let cname = std::ffi::CString::new(name).unwrap();
+        let mut varid = 0;
+        let e = unsafe { nc_inq_varid(self.0.ncid, cname.as_ptr(), &mut varid) };
+        if e == NC_ENOTFOUND {
+            return Ok(None);
+        } else {
+            error::checked(e)?;
+        }
+        let mut xtype = 0;
+        let mut ndims = 0;
+        unsafe {
+            error::checked(nc_inq_var(
+                self.0.ncid,
+                varid,
+                std::ptr::null_mut(),
+                &mut xtype,
+                &mut ndims,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            ))?;
+        }
+        let mut dimids = vec![0; ndims as _];
+        unsafe {
+            error::checked(nc_inq_vardimid(self.0.ncid, varid, dimids.as_mut_ptr()))?;
+        }
+        let dimensions = dimids
+            .into_iter()
+            .map(|id| {
+                let mut len = 0;
+                unsafe { error::checked(nc_inq_dimlen(self.0.ncid, id, &mut len))? }
+                Ok(Dimension {
+                    len: core::num::NonZeroUsize::new(len),
+                    id: Identifier {
+                        ncid: self.0.ncid,
+                        dimid: id,
+                    },
+                    _group: PhantomData,
+                })
+            })
+            .collect::<error::Result<Vec<_>>>()?;
 
-impl std::ops::Deref for ReadOnlyFile {
-    type Target = File;
-    fn deref(&self) -> &Self::Target {
-        &self.file
+        Ok(Some(Variable {
+            dimensions,
+            ncid: self.0.ncid,
+            varid,
+            vartype: xtype,
+            _group: PhantomData,
+        }))
     }
-}
-
-impl ReadOnlyFile {
-    pub(crate) fn open(path: &path::Path) -> error::Result<Self> {
-        Ok(Self {
-            file: File::open(path)?,
+    pub fn group(&self, name: &str) -> Option<Group> {
+        todo!()
+    }
+    pub fn groups<'g>(&'g self) -> impl Iterator<Item = Group<'g>> {
+        (0..).into_iter().map(|_| todo!())
+    }
+    pub fn dimension(&self, name: &str) -> Option<Dimension> {
+        let cname = std::ffi::CString::new(name).unwrap();
+        let mut dimid = 0;
+        let e = unsafe {
+            nc_inq_dimid(self.0.ncid, cname.as_ptr(), &mut dimid)
+        };
+        if e == NC_ENOTFOUND {
+            return None;
+        } else {
+            error::checked(e).unwrap();
+        }
+        let mut dimlen = 0;
+        unsafe {
+            error::checked(nc_inq_dimlen(self.0.ncid, dimid, &mut dimlen)).unwrap();
+        }
+        Some(Dimension {
+            len: core::num::NonZeroUsize::new(dimlen),
+            id: Identifier {
+                ncid: self.0.ncid,
+                dimid,
+            },
+            _group: PhantomData,
         })
+    }
+    pub fn dimensions<'g>(&'g self) -> impl Iterator<Item = Dimension<'g>> {
+        (0..).into_iter().map(|_| todo!())
+    }
+    pub fn attribute<'f>(&'f self, name: &str) -> error::Result<Option<Attribute<'f>>> {
+        if name.len() > NC_MAX_NAME as _ {
+            return Err("Name too long".into());
+        }
+        let mut cname = [0_u8; NC_MAX_NAME as usize + 1];
+        cname[..name.len()].copy_from_slice(name.as_bytes());
+        let e = unsafe {
+            let mut attid = 0;
+            nc_inq_attid(
+                self.0.ncid,
+                NC_GLOBAL,
+                cname.as_ptr() as *const _,
+                &mut attid,
+            )
+        };
+        if e == NC_ENOTATT {
+            Ok(None)
+        } else {
+            error::checked(e)?;
+            Ok(Some(Attribute {
+                name: cname,
+                ncid: self.0.ncid,
+                varid: NC_GLOBAL,
+                _marker: PhantomData,
+            }))
+        }
+    }
+    pub fn attributes<'f>(
+        &'f self,
+    ) -> error::Result<impl Iterator<Item = error::Result<Attribute<'f>>>> {
+        let _l = super::LOCK.lock().unwrap();
+        crate::attribute::AttributeIterator::new(self.0.ncid, None)
+    }
+    pub fn variables<'f>(
+        &'f self,
+    ) -> error::Result<impl Iterator<Item = error::Result<Variable<'f, 'f>>>> {
+        Ok((0..).into_iter().map(|_| todo!()))
+    }
+    fn ncid(&self) -> nc_type {
+        self.0.ncid
+    }
+}
+
+/// Mutable access to file
+#[derive(Debug)]
+pub struct MutableFile(ReadOnlyFile);
+
+impl std::ops::Deref for MutableFile {
+    type Target = ReadOnlyFile;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl MutableFile {
+    /// Creates a file
+    pub fn create(name: &std::path::Path) -> error::Result<Self> {
+        let file = File::create(name)?;
+        Ok(Self(ReadOnlyFile(file)))
+    }
+    /// Open file in append mode
+    pub fn append(name: &std::path::Path) -> error::Result<Self> {
+        let file = File::append(name)?;
+        Ok(Self(ReadOnlyFile(file)))
+    }
+    /// Mutable access to the root group
+    pub fn root_mut<'f>(&'f mut self) -> GroupMut<'f> {
+        GroupMut(self.root(), PhantomData)
+    }
+
+    pub fn add_variable<'f, T>(
+        &'f mut self,
+        name: &str,
+        dims: &[&str],
+    ) -> error::Result<VariableMut<'f, 'f>>
+    where
+        T: Numeric,
+    {
+        VariableMut::add_from_str((self.0).0.ncid, T::NCTYPE, name, dims)
+    }
+
+    pub fn add_dimension<'g>(&'g mut self, name: &str, len: usize) -> error::Result<Dimension<'g>> {
+        let cname = std::ffi::CString::new(name).unwrap();
+        let mut dimid = 0;
+        unsafe {
+            error::checked(nc_def_dim(self.ncid(), cname.as_ptr(), len, &mut dimid))?;
+        }
+        Ok(Dimension {
+            len: core::num::NonZeroUsize::new(dimid as _),
+            id: Identifier {
+                ncid: self.ncid(),
+                dimid,
+            },
+            _group: PhantomData
+        })
+    }
+    pub fn add_unlimited_dimension(&mut self, name: &str) -> error::Result<Dimension> {
+        self.add_dimension(name, 0)
+    }
+    pub fn group_mut<'f>(&'f mut self, name: &str) -> Option<GroupMut<'f>> {
+        let cname = std::ffi::CString::new(name).unwrap();
+        let mut grpid = 0;
+        unsafe {
+            error::checked(nc_inq_grp_ncid(self.ncid(), cname.as_ptr(), &mut grpid)).unwrap();
+        }
+
+        Some(GroupMut(Group {
+            ncid: self.ncid(),
+            grpid: Some(grpid),
+            _file: PhantomData,
+        }, PhantomData))
+    }
+    pub fn add_variable_from_identifiers<T>(
+        &mut self,
+        name: &str,
+        dims: &[super::dimension::Identifier],
+    ) -> error::Result<VariableMut>
+    where
+        T: Numeric,
+    {
+        let odims = dims;
+        let dims = dims.iter().map(|x| x.dimid).collect::<Vec<_>>();
+        let cname = std::ffi::CString::new(name).unwrap();
+        let xtype = T::NCTYPE;
+
+        let mut varid = 0;
+        unsafe {
+            error::checked(nc_def_var((self.0).0.ncid, cname.as_ptr(), xtype, dims.len() as _, dims.as_ptr(), &mut varid))?;
+        }
+        let dimensions = odims.into_iter().map(|id|  {
+            let mut dimlen = 0;
+            unsafe {
+                error::checked(nc_inq_dimlen(id.ncid, id.dimid, &mut dimlen))?;
+            }
+            Ok(Dimension {
+                len: core::num::NonZeroUsize::new(dimlen),
+                id: id.clone(),
+                _group: PhantomData,
+            })
+        }).collect::<error::Result<Vec<_>>>()?;
+
+        Ok(VariableMut(Variable {
+            ncid: (self.0).0.ncid,
+            dimensions,
+            varid,
+            vartype: xtype,
+            _group: PhantomData,
+        }, PhantomData))
+    }
+    pub fn add_group<'f>(&'f mut self, name: &str) -> error::Result<GroupMut<'f>> {
+        let cname = std::ffi::CString::new(name).unwrap();
+        let mut grpid = 0;
+        unsafe {
+            error::checked(nc_def_grp(self.ncid(), cname.as_ptr(), &mut grpid))?;
+        }
+
+        Ok(GroupMut(Group {
+            ncid: self.ncid(),
+            grpid: Some(grpid),
+            _file: PhantomData
+        }, PhantomData))
+    }
+    pub fn add_string_variable(&mut self, name: &str, dims: &[&str]) -> error::Result<VariableMut> {
+        VariableMut::add_from_str((self.0).0.ncid, NC_STRING, name, dims)
+    }
+    pub fn variable_mut<'g>(&'g mut self, name: &str) -> Option<VariableMut<'g, 'g>> {
+        let cname = std::ffi::CString::new(name).unwrap();
+        let mut varid = 0;
+        unsafe {
+            error::checked(nc_inq_varid(self.ncid(), cname.as_ptr(), &mut varid)).unwrap();
+        }
+        let mut ndims = 0;
+        let mut xtype = 0;
+        let ncid = self.ncid();
+        unsafe {
+            error::checked(nc_inq_var(ncid, varid, std::ptr::null_mut(), &mut xtype, &mut ndims, std::ptr::null_mut(), std::ptr::null_mut())).unwrap();
+        }
+        let mut dimids = vec![0; ndims as _];
+        unsafe {
+            error::checked(nc_inq_vardimid(ncid, varid, dimids.as_mut_ptr())).unwrap();
+        }
+
+        let dimensions = dimids.into_iter().map(|dimid| {
+            let mut dimlen = 0;
+            unsafe {
+                error::checked(nc_inq_dimlen(ncid, dimid, &mut dimlen))?;
+            }
+            Ok(Dimension {
+                len: core::num::NonZeroUsize::new(dimlen),
+                id: Identifier {
+                    ncid: ncid,
+                    dimid,
+                },
+                _group: PhantomData
+            })
+        }).collect::<error::Result<Vec<_>>>().unwrap();
+
+        Some(VariableMut(Variable {
+            ncid: self.ncid(),
+            varid,
+            dimensions,
+            vartype: xtype,
+            _group: PhantomData,
+        }, PhantomData))
+    }
+    pub fn variables_mut<'f>(
+        &'f mut self,
+    ) -> error::Result<impl Iterator<Item = VariableMut<'f, 'f>>> {
+        let mut nvars = 0;
+        unsafe {
+            error::checked(nc_inq_varids(self.ncid(), &mut nvars, std::ptr::null_mut()))?;
+        }
+        let mut varids = vec![0; nvars as _];
+        unsafe {
+            error::checked(nc_inq_varids(self.ncid(), std::ptr::null_mut(), varids.as_mut_ptr()))?;
+        }
+        let ncid = self.ncid();
+        Ok(varids.into_iter().map(move |varid| {
+            let mut ndims = 0;
+            let mut xtype = 0;
+            unsafe {
+                error::checked(nc_inq_var(ncid, varid, std::ptr::null_mut(), &mut xtype, &mut ndims, std::ptr::null_mut(), std::ptr::null_mut())).unwrap();
+            }
+            let mut dimids = vec![0; ndims as _];
+            unsafe {
+                error::checked(nc_inq_vardimid(ncid, varid, dimids.as_mut_ptr())).unwrap();
+            }
+
+            let dimensions = dimids.into_iter().map(|dimid| {
+                let mut dimlen = 0;
+                unsafe {
+                    error::checked(nc_inq_dimlen(ncid, dimid, &mut dimlen))?;
+                }
+                Ok(Dimension {
+                    len: core::num::NonZeroUsize::new(dimlen),
+                    id: Identifier {
+                        ncid: ncid,
+                        dimid,
+                    },
+                    _group: PhantomData
+                })
+            }).collect::<error::Result<Vec<_>>>().unwrap();
+
+            VariableMut(Variable {
+                ncid: self.ncid(),
+                varid,
+                dimensions,
+                vartype: xtype,
+                _group: PhantomData,
+            }, PhantomData)
+        }))
+    }
+    pub fn add_attribute<'a, T>(&'a mut self, name: &str, val: T) -> error::Result<Attribute<'a>>
+    where
+        T: Into<AttrValue>,
+    {
+        Attribute::put((self.0).0.ncid, NC_GLOBAL, name, val.into())
     }
 }
 
@@ -180,13 +473,13 @@ impl ReadOnlyFile {
 /// ```
 #[allow(clippy::module_name_repetitions)]
 pub struct MemFile<'a> {
-    file: File,
+    file: ReadOnlyFile,
     _buffer: std::marker::PhantomData<&'a [u8]>,
 }
 
 #[cfg(feature = "memory")]
 impl<'a> std::ops::Deref for MemFile<'a> {
-    type Target = File;
+    type Target = ReadOnlyFile;
     fn deref(&self) -> &Self::Target {
         &self.file
     }
@@ -209,263 +502,9 @@ impl<'a> MemFile<'a> {
             ))?;
         }
 
-        let root = parse_file(ncid)?;
-
         Ok(Self {
-            file: File {
-                name: name.unwrap_or("").to_string(),
-                ncid,
-                root,
-            },
+            file: File { ncid },
             _buffer: std::marker::PhantomData,
         })
     }
-}
-
-impl Drop for File {
-    fn drop(&mut self) {
-        unsafe {
-            let _g = LOCK.lock().unwrap();
-            // Can't really do much with an error here
-            let _err = error::checked(nc_close(self.ncid));
-        }
-    }
-}
-
-use super::dimension::Dimension;
-
-fn get_group_dimensions(ncid: nc_type) -> error::Result<Vec<Dimension>> {
-    let mut ndims: nc_type = 0;
-    unsafe {
-        error::checked(nc_inq_dimids(ncid, &mut ndims, std::ptr::null_mut(), 0))?;
-    }
-
-    if ndims == 0 {
-        return Ok(Vec::new());
-    }
-    let mut dimids = vec![0 as nc_type; ndims.try_into()?];
-    unsafe {
-        error::checked(nc_inq_dimids(
-            ncid,
-            std::ptr::null_mut(),
-            dimids.as_mut_ptr(),
-            0,
-        ))?;
-    }
-
-    let unlimited_dims = get_unlimited_dimensions(ncid)?;
-    let mut dimensions = Vec::with_capacity(ndims.try_into()?);
-    for dimid in dimids {
-        let mut len = 0;
-        unsafe {
-            error::checked(nc_inq_dim(ncid, dimid as _, std::ptr::null_mut(), &mut len))?;
-        }
-
-        let len = if unlimited_dims.contains(&dimid) {
-            None
-        } else {
-            Some(unsafe { core::num::NonZeroUsize::new_unchecked(len) })
-        };
-        dimensions.push(Dimension {
-            len,
-            id: super::dimension::Identifier { ncid, dimid },
-        });
-    }
-
-    Ok(dimensions)
-}
-
-fn get_dimensions_of_var(
-    ncid: nc_type,
-    varid: nc_type,
-    g: &Group,
-) -> error::Result<Vec<Dimension>> {
-    let mut ndims = 0;
-    unsafe {
-        error::checked(nc_inq_var(
-            ncid,
-            varid,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            &mut ndims,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-        ))?;
-    }
-    if ndims == 0 {
-        return Ok(Vec::new());
-    }
-    let mut dimids = vec![0; ndims.try_into()?];
-    unsafe {
-        error::checked(nc_inq_var(
-            ncid,
-            varid,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            dimids.as_mut_ptr(),
-            std::ptr::null_mut(),
-        ))?;
-    }
-
-    let mut dimensions = Vec::with_capacity(ndims.try_into()?);
-    for dimid in dimids {
-        let d = if let Some(d) = g.dimensions().find(|x| x.id.dimid == dimid) {
-            d
-        } else if let Some(d) = g
-            .parents()
-            .flat_map(Group::dimensions)
-            .find(|x| x.id.dimid == dimid)
-        {
-            d
-        } else {
-            return Err(error::Error::NotFound(format!("dimid {}", dimid)));
-        };
-
-        dimensions.push(d.clone());
-    }
-
-    Ok(dimensions)
-}
-
-use super::Variable;
-fn get_variables(ncid: nc_type, g: &Group) -> error::Result<Vec<Variable>> {
-    let mut nvars = 0;
-    unsafe {
-        error::checked(nc_inq_varids(ncid, &mut nvars, std::ptr::null_mut()))?;
-    }
-    if nvars == 0 {
-        return Ok(Vec::new());
-    }
-    let mut varids = vec![0; nvars.try_into()?];
-    unsafe {
-        error::checked(nc_inq_varids(
-            ncid,
-            std::ptr::null_mut(),
-            varids.as_mut_ptr(),
-        ))?;
-    }
-
-    let mut variables = Vec::with_capacity(nvars.try_into()?);
-    for varid in varids {
-        let mut vartype = 0;
-        unsafe {
-            error::checked(nc_inq_var(
-                ncid,
-                varid,
-                std::ptr::null_mut(),
-                &mut vartype,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-            ))?;
-        }
-        let dimensions = get_dimensions_of_var(ncid, varid, g)?;
-
-        let v = Variable {
-            ncid,
-            varid,
-            dimensions,
-            vartype,
-        };
-
-        variables.push(v);
-    }
-
-    Ok(variables)
-}
-
-fn get_groups(
-    ncid: nc_type,
-    parent: &Rc<UnsafeCell<Group>>,
-) -> error::Result<Vec<Rc<UnsafeCell<Group>>>> {
-    let mut ngroups = 0;
-
-    unsafe {
-        error::checked(nc_inq_grps(ncid, &mut ngroups, std::ptr::null_mut()))?;
-    }
-    if ngroups == 0 {
-        return Ok(Vec::new());
-    }
-    let mut grpids = vec![0; ngroups.try_into()?];
-    unsafe {
-        error::checked(nc_inq_grps(ncid, std::ptr::null_mut(), grpids.as_mut_ptr()))?;
-    }
-
-    let mut groups = Vec::with_capacity(ngroups.try_into()?);
-    for grpid in grpids {
-        let g = Rc::new(UnsafeCell::new(Group {
-            ncid,
-            grpid: Some(grpid),
-            dimensions: Vec::new(),
-            variables: Vec::new(),
-            groups: Vec::new(),
-            parent: Some(Rc::downgrade(parent)),
-            this: None,
-        }));
-
-        let refcell = Rc::downgrade(&g);
-        let gref = unsafe { &mut *g.get() };
-        gref.this = Some(refcell);
-
-        let dimensions = get_group_dimensions(grpid)?;
-        gref.dimensions = dimensions;
-        let variables = get_variables(grpid, &gref)?;
-        gref.variables = variables;
-
-        let subgroups = get_groups(grpid, &g)?;
-        gref.groups = subgroups;
-
-        groups.push(g);
-    }
-
-    Ok(groups)
-}
-
-fn get_unlimited_dimensions(ncid: nc_type) -> error::Result<Vec<nc_type>> {
-    let mut nunlim = 0;
-    unsafe {
-        error::checked(nc_inq_unlimdims(ncid, &mut nunlim, std::ptr::null_mut()))?;
-    }
-
-    let mut uldim = vec![0; nunlim.try_into()?];
-    unsafe {
-        error::checked(nc_inq_unlimdims(
-            ncid,
-            std::ptr::null_mut(),
-            uldim.as_mut_ptr(),
-        ))?;
-    }
-    Ok(uldim)
-}
-
-fn parse_file(ncid: nc_type) -> error::Result<Rc<UnsafeCell<Group>>> {
-    let _l = LOCK.lock().unwrap();
-
-    let g = Rc::new(UnsafeCell::new(Group {
-        ncid,
-        grpid: None,
-        dimensions: Vec::new(),
-        variables: Vec::new(),
-        groups: Vec::new(),
-        parent: None,
-        this: None,
-    }));
-    let thisref = Some(Rc::downgrade(&g));
-    {
-        let g = unsafe { &mut *g.get() };
-        g.this = thisref;
-    }
-    let gref = unsafe { &mut *g.get() };
-
-    let dimensions = get_group_dimensions(ncid)?;
-    gref.dimensions = dimensions;
-
-    let variables = get_variables(ncid, gref)?;
-    gref.variables = variables;
-
-    let groups = get_groups(ncid, &g)?;
-    gref.groups = groups;
-
-    Ok(g)
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -193,10 +193,12 @@ impl MutableFile {
     where
         T: Numeric,
     {
+        let _l = LOCK.lock().unwrap();
         VariableMut::add_from_str(self.ncid(), T::NCTYPE, name, dims)
     }
 
     pub fn add_dimension<'g>(&'g mut self, name: &str, len: usize) -> error::Result<Dimension<'g>> {
+        let _l = LOCK.lock().unwrap();
         super::dimension::add_dimension_at(self.ncid(), name, len)
     }
     pub fn add_unlimited_dimension(&mut self, name: &str) -> error::Result<Dimension> {
@@ -217,12 +219,15 @@ impl MutableFile {
     where
         T: Numeric,
     {
+        let _l = LOCK.lock().unwrap();
         super::variable::add_variable_from_identifiers(self.ncid(), name, dims, T::NCTYPE)
     }
     pub fn add_group<'f>(&'f mut self, name: &str) -> error::Result<GroupMut<'f>> {
+        let _l = LOCK.lock().unwrap();
         GroupMut::add_group_at(self.ncid(), name)
     }
     pub fn add_string_variable(&mut self, name: &str, dims: &[&str]) -> error::Result<VariableMut> {
+        let _l = LOCK.lock().unwrap();
         VariableMut::add_from_str(self.ncid(), NC_STRING, name, dims)
     }
     pub fn variable_mut<'g>(
@@ -242,6 +247,7 @@ impl MutableFile {
     where
         T: Into<AttrValue>,
     {
+        let _l = LOCK.lock().unwrap();
         Attribute::put(self.ncid(), NC_GLOBAL, name, val.into())
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -137,16 +137,16 @@ impl ReadOnlyFile {
     pub fn group(&self, name: &str) -> error::Result<Option<Group>> {
         super::group::group_from_name(self.ncid(), name)
     }
-    pub fn groups<'g>(&'g self) -> impl Iterator<Item = Group<'g>> {
-        super::group::groups_at_ncid(self.ncid()).unwrap()
+    pub fn groups<'g>(&'g self) -> error::Result<impl Iterator<Item = Group<'g>>> {
+        super::group::groups_at_ncid(self.ncid())
     }
-    pub fn dimension<'f>(&self, name: &str) -> Option<Dimension<'f>> {
-        super::dimension::dimension_from_name(self.ncid(), name).unwrap()
+    pub fn dimension<'f>(&self, name: &str) -> error::Result<Option<Dimension<'f>>> {
+        super::dimension::dimension_from_name(self.ncid(), name)
     }
-    pub fn dimensions<'g>(&'g self) -> impl Iterator<Item = Dimension<'g>> {
+    pub fn dimensions<'g>(
+        &'g self,
+    ) -> error::Result<impl Iterator<Item = error::Result<Dimension<'g>>>> {
         super::dimension::dimensions_from_location(self.ncid())
-            .unwrap()
-            .map(|x| x.unwrap())
     }
     pub fn attribute<'f>(&'f self, name: &str) -> error::Result<Option<Attribute<'f>>> {
         Attribute::find_from_name(self.ncid(), None, name)
@@ -230,9 +230,9 @@ impl MutableFile {
     }
     pub fn variables_mut<'f>(
         &'f mut self,
-    ) -> error::Result<impl Iterator<Item = VariableMut<'f, 'f>>> {
+    ) -> error::Result<impl Iterator<Item = error::Result<VariableMut<'f, 'f>>>> {
         self.variables()
-            .map(|v| v.map(|var| VariableMut(var.unwrap(), PhantomData)))
+            .map(|v| v.map(|var| var.map(|var| VariableMut(var, PhantomData))))
     }
     pub fn add_attribute<'a, T>(&'a mut self, name: &str, val: T) -> error::Result<Attribute<'a>>
     where

--- a/src/file.rs
+++ b/src/file.rs
@@ -205,6 +205,9 @@ impl MutableFile {
         self.group(name)
             .map(|g| g.map(|g| GroupMut(g, PhantomData)))
     }
+    pub fn groups_mut<'f>(&'f mut self) -> error::Result<impl Iterator<Item = GroupMut<'f>>> {
+        self.groups().map(|g| g.map(|g| GroupMut(g, PhantomData)))
+    }
     pub fn add_variable_from_identifiers<T>(
         &mut self,
         name: &str,

--- a/src/file.rs
+++ b/src/file.rs
@@ -365,17 +365,13 @@ fn get_variables(ncid: nc_type, g: &Group) -> error::Result<Vec<Variable>> {
     }
 
     let mut variables = Vec::with_capacity(nvars.try_into()?);
-    let mut name = [0_u8; NC_MAX_NAME as usize + 1];
     for varid in varids {
-        for i in name.iter_mut() {
-            *i = 0;
-        }
         let mut vartype = 0;
         unsafe {
             error::checked(nc_inq_var(
                 ncid,
                 varid,
-                name.as_mut_ptr() as *mut _,
+                std::ptr::null_mut(),
                 &mut vartype,
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
@@ -384,17 +380,10 @@ fn get_variables(ncid: nc_type, g: &Group) -> error::Result<Vec<Variable>> {
         }
         let dimensions = get_dimensions_of_var(ncid, varid, g)?;
 
-        let zero_pos = name
-            .iter()
-            .position(|&x| x == 0)
-            .unwrap_or_else(|| name.len());
-        let name = String::from(String::from_utf8_lossy(&name[..zero_pos]));
-
         let v = Variable {
             ncid,
             varid,
             dimensions,
-            name,
             vartype,
         };
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -117,7 +117,6 @@ impl File {
         }
 
         let root = Rc::new(UnsafeCell::new(Group {
-            name: "root".to_string(),
             ncid,
             grpid: None,
             variables: Vec::default(),
@@ -394,21 +393,8 @@ fn get_groups(
     }
 
     let mut groups = Vec::with_capacity(ngroups.try_into()?);
-    let mut cname = [0; NC_MAX_NAME as usize + 1];
     for grpid in grpids {
-        for i in cname.iter_mut() {
-            *i = 0;
-        }
-        unsafe {
-            error::checked(nc_inq_grpname(grpid, cname.as_mut_ptr()))?;
-        }
-
-        let name = unsafe { std::ffi::CStr::from_ptr(cname.as_ptr()) }
-            .to_string_lossy()
-            .to_string();
-
         let g = Rc::new(UnsafeCell::new(Group {
-            name: name.clone(),
             ncid,
             grpid: Some(grpid),
             dimensions: Vec::new(),
@@ -459,7 +445,6 @@ fn parse_file(ncid: nc_type) -> error::Result<Rc<UnsafeCell<Group>>> {
     let g = Rc::new(UnsafeCell::new(Group {
         ncid,
         grpid: None,
-        name: "root".into(),
         dimensions: Vec::new(),
         variables: Vec::new(),
         groups: Vec::new(),

--- a/src/file.rs
+++ b/src/file.rs
@@ -149,6 +149,7 @@ impl ReadOnlyFile {
         super::dimension::dimensions_from_location(self.ncid())
     }
     pub fn attribute<'f>(&'f self, name: &str) -> error::Result<Option<Attribute<'f>>> {
+        let _l = super::LOCK.lock().unwrap();
         Attribute::find_from_name(self.ncid(), None, name)
     }
     pub fn attributes<'f>(

--- a/src/group.rs
+++ b/src/group.rs
@@ -145,10 +145,10 @@ impl<'f> GroupMut<'f> {
     }
 
     pub(crate) fn add_group_at(ncid: nc_type, name: &str) -> error::Result<Self> {
-        let cstr = std::ffi::CString::new(name).unwrap();
+        let cname = super::utils::short_name_to_bytes(name)?;
         let mut grpid = 0;
         unsafe {
-            error::checked(nc_def_grp(ncid, cstr.as_ptr(), &mut grpid))?;
+            error::checked(nc_def_grp(ncid, cname.as_ptr() as *const _, &mut grpid))?;
         }
 
         Ok(Self(
@@ -217,9 +217,9 @@ pub(crate) fn groups_at_ncid<'f>(ncid: nc_type) -> error::Result<impl Iterator<I
 }
 
 pub(crate) fn group_from_name<'f>(ncid: nc_type, name: &str) -> error::Result<Option<Group<'f>>> {
-    let cname = std::ffi::CString::new(name).unwrap();
+    let cname = super::utils::short_name_to_bytes(name)?;
     let mut grpid = 0;
-    let e = unsafe { nc_inq_grp_ncid(ncid, cname.as_ptr(), &mut grpid) };
+    let e = unsafe { nc_inq_grp_ncid(ncid, cname.as_ptr() as *const _, &mut grpid) };
     if e == NC_ENOTFOUND {
         return Ok(None);
     } else {

--- a/src/group.rs
+++ b/src/group.rs
@@ -144,7 +144,9 @@ impl<'f> Group<'f> {
     }
     /// Iterator over all dimensions
     pub fn dimensions<'g>(&'g self) -> impl Iterator<Item = Dimension<'g>> {
-        (0..).into_iter().map(|_| todo!())
+        super::dimension::dimension_iterator(self.id())
+            .unwrap()
+            .map(|x| x.unwrap())
     }
     /// Get a group
     pub fn group(&self, name: &str) -> Option<Self> {

--- a/src/group.rs
+++ b/src/group.rs
@@ -63,6 +63,7 @@ impl<'f> Group<'f> {
     ) -> error::Result<impl Iterator<Item = error::Result<Variable<'f, 'g>>>> {
         super::variable::variables_at_ncid(self.id())
     }
+
     /// Get a single attribute
     pub fn attribute<'a>(&'a self, name: &str) -> error::Result<Option<Attribute<'a>>> {
         let _l = super::LOCK.lock().unwrap();
@@ -74,6 +75,7 @@ impl<'f> Group<'f> {
         let _l = super::LOCK.lock().unwrap();
         crate::attribute::AttributeIterator::new(self.ncid, None)
     }
+
     /// Get a single dimension
     pub fn dimension(&self, name: &str) -> error::Result<Option<Dimension>> {
         super::dimension::dimension_from_name(self.id(), name)
@@ -84,6 +86,7 @@ impl<'f> Group<'f> {
     ) -> error::Result<impl Iterator<Item = error::Result<Dimension<'g>>>> {
         super::dimension::dimensions_from_location(self.id())
     }
+
     /// Get a group
     pub fn group(&self, name: &str) -> error::Result<Option<Self>> {
         group_from_name(self.id(), name)
@@ -110,7 +113,8 @@ impl<'f> GroupMut<'f> {
         self.variables()
             .map(|var| var.map(|var| var.map(|var| VariableMut(var, PhantomData))))
     }
-    /// Mutable access to group
+
+    /// Mutable access to subgroup
     pub fn group_mut(&'f mut self, name: &str) -> error::Result<Option<Self>> {
         self.group(name)
             .map(|g| g.map(|g| GroupMut(g, PhantomData)))
@@ -161,19 +165,6 @@ impl<'f> GroupMut<'f> {
         let _l = LOCK.lock().unwrap();
         Self::add_group_at(self.id(), name)
     }
-    /// Adds a variable from a set of unique identifiers, recursing upwards
-    /// from the current group if necessary.
-    pub fn add_variable_from_identifiers<T>(
-        &mut self,
-        name: &str,
-        dims: &[super::dimension::Identifier],
-    ) -> error::Result<VariableMut>
-    where
-        T: Numeric,
-    {
-        let _l = LOCK.lock().unwrap();
-        super::variable::add_variable_from_identifiers(self.id(), name, dims, T::NCTYPE)
-    }
 
     /// Create a Variable into the dataset, with no data written into it
     ///
@@ -190,11 +181,23 @@ impl<'f> GroupMut<'f> {
         let _l = LOCK.lock().unwrap();
         VariableMut::add_from_str(self.id(), T::NCTYPE, name, dims)
     }
-
     /// Adds a variable with a basic type of string
     pub fn add_string_variable(&mut self, name: &str, dims: &[&str]) -> error::Result<VariableMut> {
         let _l = LOCK.lock().unwrap();
         VariableMut::add_from_str(self.id(), NC_STRING, name, dims)
+    }
+    /// Adds a variable from a set of unique identifiers, recursing upwards
+    /// from the current group if necessary.
+    pub fn add_variable_from_identifiers<T>(
+        &mut self,
+        name: &str,
+        dims: &[super::dimension::Identifier],
+    ) -> error::Result<VariableMut>
+    where
+        T: Numeric,
+    {
+        let _l = LOCK.lock().unwrap();
+        super::variable::add_variable_from_identifiers(self.id(), name, dims, T::NCTYPE)
     }
 }
 

--- a/src/group.rs
+++ b/src/group.rs
@@ -259,7 +259,7 @@ pub(crate) fn group_from_name<'f>(ncid: nc_type, name: &str) -> error::Result<Op
     let byte_name = super::utils::short_name_to_bytes(name)?;
     let mut grpid = 0;
     let e = unsafe { nc_inq_grp_ncid(ncid, byte_name.as_ptr() as *const _, &mut grpid) };
-    if e == NC_ENOTFOUND {
+    if e == NC_ENOGRP {
         return Ok(None);
     } else {
         error::checked(e)?;

--- a/src/group.rs
+++ b/src/group.rs
@@ -6,6 +6,7 @@ use super::attribute::Attribute;
 use super::dimension::Dimension;
 use super::error;
 use super::variable::{Numeric, Variable, VariableMut};
+use super::LOCK;
 use netcdf_sys::*;
 use std::marker::PhantomData;
 
@@ -124,11 +125,13 @@ impl<'f> GroupMut<'f> {
     where
         T: Into<AttrValue>,
     {
+        let _l = LOCK.lock().unwrap();
         Attribute::put(self.ncid, NC_GLOBAL, name, val.into())
     }
 
     /// Adds a dimension with the given name and size. A size of zero gives an unlimited dimension
     pub fn add_dimension<'g>(&'g mut self, name: &str, len: usize) -> error::Result<Dimension<'g>> {
+        let _l = LOCK.lock().unwrap();
         super::dimension::add_dimension_at(self.id(), name, len)
     }
 
@@ -155,6 +158,7 @@ impl<'f> GroupMut<'f> {
 
     /// Add an empty group to the dataset
     pub fn add_group(&mut self, name: &str) -> error::Result<Self> {
+        let _l = LOCK.lock().unwrap();
         Self::add_group_at(self.id(), name)
     }
     /// Adds a variable from a set of unique identifiers, recursing upwards
@@ -167,6 +171,7 @@ impl<'f> GroupMut<'f> {
     where
         T: Numeric,
     {
+        let _l = LOCK.lock().unwrap();
         super::variable::add_variable_from_identifiers(self.id(), name, dims, T::NCTYPE)
     }
 
@@ -182,11 +187,13 @@ impl<'f> GroupMut<'f> {
     where
         T: Numeric,
     {
+        let _l = LOCK.lock().unwrap();
         VariableMut::add_from_str(self.id(), T::NCTYPE, name, dims)
     }
 
     /// Adds a variable with a basic type of string
     pub fn add_string_variable(&mut self, name: &str, dims: &[&str]) -> error::Result<VariableMut> {
+        let _l = LOCK.lock().unwrap();
         VariableMut::add_from_str(self.id(), NC_STRING, name, dims)
     }
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -208,16 +208,16 @@ impl Group {
         }
         let mut d: Vec<_> = Vec::default();
         for (i, dim) in dims.iter().enumerate() {
-            let id = dim.identifier;
+            let id = dim.dimid;
             let found_dim = match self
                 .dimensions()
-                .find(|&x| x.ncid == dim.ncid && x.id == id)
+                .find(|&x| x.id.ncid == dim.ncid && x.id.dimid == id)
             {
                 Some(x) => x.clone(),
                 None => match self
                     .parents()
                     .flat_map(Self::dimensions)
-                    .find(|d| d.ncid == dim.ncid && d.id == id)
+                    .find(|d| d.id.ncid == dim.ncid && d.id.dimid == id)
                 {
                     Some(d) => d.clone(),
                     None => return Err(error::Error::NotFound(format!("dimension #{}", i))),

--- a/src/group.rs
+++ b/src/group.rs
@@ -40,7 +40,7 @@ impl Group {
     }
     /// Get a variable from the group
     pub fn variable(&self, name: &str) -> Option<&Variable> {
-        self.variables().find(|x| x.name() == name)
+        self.variables().find(|x| x.name().unwrap() == name)
     }
     /// Iterate over all variables in a group
     pub fn variables(&self) -> impl Iterator<Item = &Variable> {
@@ -48,7 +48,7 @@ impl Group {
     }
     /// Get a mutable variable from the group
     pub fn variable_mut(&mut self, name: &str) -> Option<&mut Variable> {
-        self.variables_mut().find(|x| x.name() == name)
+        self.variables_mut().find(|x| x.name().unwrap() == name)
     }
     /// Iterate over all variables in a group, with mutable access
     pub fn variables_mut(&mut self) -> impl Iterator<Item = &mut Variable> {

--- a/src/group.rs
+++ b/src/group.rs
@@ -67,7 +67,7 @@ impl Group {
     }
     /// Get a single dimension
     pub fn dimension(&self, name: &str) -> Option<&Dimension> {
-        self.dimensions().find(|x| x.name() == name)
+        self.dimensions().find(|x| x.name().unwrap() == name)
     }
     /// Iterator over all dimensions
     pub fn dimensions(&self) -> impl Iterator<Item = &Dimension> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub fn create<P>(name: P) -> error::Result<MutableFile>
 where
     P: AsRef<std::path::Path>,
 {
-    MutableFile::create(name.as_ref())
+    File::create(name.as_ref())
 }
 
 /// Open a netcdf file in append mode
@@ -96,7 +96,7 @@ pub fn append<P>(name: P) -> error::Result<MutableFile>
 where
     P: AsRef<std::path::Path>,
 {
-    MutableFile::append(name.as_ref())
+    File::append(name.as_ref())
 }
 
 /// Open a netcdf file in read mode
@@ -104,13 +104,13 @@ pub fn open<P>(name: P) -> error::Result<ReadOnlyFile>
 where
     P: AsRef<std::path::Path>,
 {
-    ReadOnlyFile::open(name.as_ref())
+    File::open(name.as_ref())
 }
 
 #[cfg(feature = "memory")]
 /// Open a netcdf file from a buffer
 pub fn open_mem<'a>(name: Option<&str>, mem: &'a [u8]) -> error::Result<MemFile<'a>> {
-    file::MemFile::new(name, mem)
+    File::open_from_memory(name, mem)
 }
 
 lazy_static! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,3 +117,20 @@ lazy_static! {
     /// Use this when accessing netcdf functions
     pub(crate) static ref LOCK: Mutex<()> = Mutex::new(());
 }
+
+pub(crate) mod utils {
+    use super::*;
+    use netcdf_sys::{NC_EMAXNAME, NC_MAX_NAME};
+    /// Use this function for short netcdf names to avoid the allocation
+    /// for a `CString`
+    pub(crate) fn short_name_to_bytes(name: &str) -> error::Result<[u8; NC_MAX_NAME as usize + 1]> {
+        if name.len() > NC_MAX_NAME as _ {
+            Err(NC_EMAXNAME.into())
+        } else {
+            let len = name.bytes().position(|x| x == 0).unwrap_or(name.len());
+            let mut bytes = [0_u8; NC_MAX_NAME as usize + 1];
+            bytes[..len].copy_from_slice(name.as_bytes());
+            Ok(bytes)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! // open it in read/write mode
 //! let mut file = netcdf::append("crabs2.nc")?;
 //! // get a mutable binding of the variable "crab_coolness_level"
-//! let mut var = file.variable_mut("crab_coolness_level").unwrap();
+//! let mut var = file.variable_mut("crab_coolness_level")?.unwrap();
 //!
 //! let data : Vec<i32> = vec![100; 10];
 //! // write 5 first elements of the vector `data` into `var` starting at index 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! # Ok(()) }
 //! ```
 
-#![warn(missing_docs)]
+// #![warn(missing_docs)]
 #![allow(clippy::must_use_candidate)]
 
 use lazy_static::lazy_static;
@@ -84,19 +84,19 @@ pub use variable::*;
 /// Open a netcdf file in create mode
 ///
 /// Will overwrite exising file
-pub fn create<P>(name: P) -> error::Result<File>
+pub fn create<P>(name: P) -> error::Result<MutableFile>
 where
     P: AsRef<std::path::Path>,
 {
-    File::create(name.as_ref())
+    MutableFile::create(name.as_ref())
 }
 
 /// Open a netcdf file in append mode
-pub fn append<P>(name: P) -> error::Result<File>
+pub fn append<P>(name: P) -> error::Result<MutableFile>
 where
     P: AsRef<std::path::Path>,
 {
-    File::append(name.as_ref())
+    MutableFile::append(name.as_ref())
 }
 
 /// Open a netcdf file in read mode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! # Ok(()) }
 //! ```
 
-// #![warn(missing_docs)]
+#![warn(missing_docs)]
 #![allow(clippy::must_use_candidate)]
 
 use lazy_static::lazy_static;
@@ -127,7 +127,10 @@ pub(crate) mod utils {
         if name.len() > NC_MAX_NAME as _ {
             Err(NC_EMAXNAME.into())
         } else {
-            let len = name.bytes().position(|x| x == 0).unwrap_or(name.len());
+            let len = name
+                .bytes()
+                .position(|x| x == 0)
+                .unwrap_or_else(|| name.len());
             let mut bytes = [0_u8; NC_MAX_NAME as usize + 1];
             bytes[..len].copy_from_slice(name.as_bytes());
             Ok(bytes)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! let file = netcdf::open("simle_xy.nc")?;
 //!
 //! // Access any variable, attribute, or dimension through lookups on hashmaps
-//! let var = &file.variable("data").expect("Could not find variable 'data'");
+//! let var = &file.variable("data")?.expect("Could not find variable 'data'");
 //!
 //! // Read variable as numeric types
 //! let data_i32 = var.value::<i32>(None)?;
@@ -36,7 +36,7 @@
 //! let var_name = "crab_coolness_level";
 //! let data : Vec<i32> = vec![42; 10];
 //! // Variable type written to file
-//! let var = file.add_variable::<i32>(
+//! let mut var = file.add_variable::<i32>(
 //!             var_name,
 //!             &[dim_name],
 //! )?;

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -15,7 +15,7 @@ use std::marker::Sized;
 
 #[allow(clippy::doc_markdown)]
 /// This struct defines a netCDF variable.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Variable<'f, 'g> {
     /// The variable name
     pub(crate) dimensions: Vec<Dimension<'f>>,

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -27,6 +27,7 @@ pub struct Variable<'f, 'g> {
 }
 
 #[derive(Debug)]
+/// Mutable access to a variable
 pub struct VariableMut<'f, 'g>(
     pub(crate) Variable<'f, 'g>,
     pub(crate) PhantomData<&'g mut nc_type>,

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1102,7 +1102,12 @@ impl<'f, 'g> VariableMut<'f, 'g> {
 }
 
 impl<'f, 'g> VariableMut<'f, 'g> {
-    pub(crate) fn add_from_str(ncid: nc_type, xtype: nc_type, name: &str, dims: &[&str]) -> error::Result<Self> {
+    pub(crate) fn add_from_str(
+        ncid: nc_type,
+        xtype: nc_type,
+        name: &str,
+        dims: &[&str],
+    ) -> error::Result<Self> {
         let dimensions = dims
             .iter()
             .map(|dimname| super::dimension::from_name_toid(ncid, dimname))
@@ -1111,7 +1116,14 @@ impl<'f, 'g> VariableMut<'f, 'g> {
         let cname = std::ffi::CString::new(name).unwrap();
         let mut varid = 0;
         unsafe {
-            error::checked(nc_def_var(ncid, cname.as_ptr(), xtype, dimensions.len() as _, dimensions.as_ptr(), &mut varid))?;
+            error::checked(nc_def_var(
+                ncid,
+                cname.as_ptr(),
+                xtype,
+                dimensions.len() as _,
+                dimensions.as_ptr(),
+                &mut varid,
+            ))?;
         }
 
         let dimensions = dims
@@ -1119,14 +1131,15 @@ impl<'f, 'g> VariableMut<'f, 'g> {
             .map(|dimname| super::dimension::from_name(ncid, dimname))
             .collect::<error::Result<Vec<_>>>()?;
 
-        Ok( VariableMut (
-                Variable {
-                    ncid: ncid,
-                    varid: varid,
-                    vartype: xtype,
-                    dimensions: dimensions,
-                    _group: PhantomData,
-            }, PhantomData)
-        )
+        Ok(VariableMut(
+            Variable {
+                ncid: ncid,
+                varid: varid,
+                vartype: xtype,
+                dimensions: dimensions,
+                _group: PhantomData,
+            },
+            PhantomData,
+        ))
     }
 }

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -656,7 +656,7 @@ impl Variable {
         use std::ffi::CString;
         let cname = CString::new(name).unwrap();
 
-        let dimids: Vec<nc_type> = dims.iter().map(|x| x.id).collect();
+        let dimids: Vec<nc_type> = dims.iter().map(|x| x.id.dimid).collect();
         let mut id = 0;
         unsafe {
             let _l = LOCK.lock().unwrap();

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -81,20 +81,7 @@ impl<'f, 'g> Variable<'f, 'g> {
         unsafe {
             error::checked(nc_inq_vardimid(ncid, varid, dimids.as_mut_ptr()))?;
         }
-        let dimensions = dimids
-            .into_iter()
-            .map(|id| {
-                let mut len = 0;
-                unsafe { error::checked(nc_inq_dimlen(ncid, id, &mut len))? }
-                Ok(Dimension {
-                    len: core::num::NonZeroUsize::new(len),
-                    id: super::dimension::Identifier {
-                        ncid: ncid,
-                        dimid: id,
-                    },
-                    _group: PhantomData,
-                })
-            })
+        let dimensions = super::dimension::dimensions_from_variable(ncid, varid)?
             .collect::<error::Result<Vec<_>>>()?;
 
         Ok(Some(Variable {

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -157,7 +157,6 @@ impl<'f, 'g> VariableMut<'f, 'g> {
     /// compression (good for CPU bound tasks), and 9 providing the
     /// highest compression level (good for memory bound tasks)
     pub fn compression(&mut self, deflate_level: nc_type) -> error::Result<()> {
-        let _l = LOCK.lock().unwrap();
         unsafe {
             error::checked(nc_def_var_deflate(
                 self.ncid,
@@ -178,7 +177,6 @@ impl<'f, 'g> VariableMut<'f, 'g> {
     /// the file. This has no effect on the memory order when reading/putting
     /// a buffer.
     pub fn chunking(&mut self, chunksize: &[usize]) -> error::Result<()> {
-        let _l = LOCK.lock().unwrap();
         if chunksize.len() != self.dimensions.len() {
             return Err(error::Error::SliceLen);
         }
@@ -480,7 +478,6 @@ macro_rules! impl_numeric {
                 indices: &[usize],
                 value: Self,
             ) -> error::Result<()> {
-                let _g = LOCK.lock().unwrap();
                 error::checked($nc_put_var1_type(
                     variable.ncid,
                     variable.varid,
@@ -496,7 +493,6 @@ macro_rules! impl_numeric {
                 slice_len: &[usize],
                 values: &[Self],
             ) -> error::Result<()> {
-                let _l = LOCK.lock().unwrap();
                 error::checked($nc_put_vara_type(
                     variable.ncid,
                     variable.varid,
@@ -531,7 +527,6 @@ macro_rules! impl_numeric {
                 strides: &[isize],
                 values: *const Self,
             ) -> error::Result<()> {
-                let _l = LOCK.lock().unwrap();
                 error::checked($nc_put_vars_type(
                     variable.ncid,
                     variable.varid,
@@ -694,6 +689,7 @@ impl<'f, 'g> VariableMut<'f, 'g> {
     where
         T: Into<AttrValue>,
     {
+        let _l = LOCK.lock().unwrap();
         Attribute::put(self.ncid, self.varid, name, val.into())
     }
 }
@@ -725,10 +721,10 @@ impl<'f, 'g> Variable<'f, 'g> {
             indices_ = self.default_indices(false)?;
             &indices_
         };
-        let _l = LOCK.lock().unwrap();
 
         let mut s: *mut std::os::raw::c_char = std::ptr::null_mut();
         unsafe {
+            let _l = LOCK.lock().unwrap();
             error::checked(nc_get_var1_string(
                 self.ncid,
                 self.varid,
@@ -785,8 +781,8 @@ impl<'f, 'g> Variable<'f, 'g> {
         }
         let mut location = std::mem::MaybeUninit::uninit();
         let mut nofill: nc_type = 0;
-        let _l = LOCK.lock().unwrap();
         unsafe {
+            let _l = LOCK.lock().unwrap();
             error::checked(nc_inq_var_fill(
                 self.ncid,
                 self.varid,
@@ -936,8 +932,6 @@ impl<'f, 'g> VariableMut<'f, 'g> {
         let value = std::ffi::CString::new(value).expect("String contained interior 0");
         let mut ptr = value.as_ptr();
 
-        let _l = LOCK.lock().unwrap();
-
         unsafe {
             error::checked(nc_put_var1_string(
                 self.ncid,
@@ -1059,7 +1053,6 @@ impl<'f, 'g> VariableMut<'f, 'g> {
         if T::NCTYPE != self.vartype {
             return Err(error::Error::TypeMismatch);
         }
-        let _l = LOCK.lock().unwrap();
         unsafe {
             error::checked(nc_def_var_fill(
                 self.ncid,
@@ -1079,7 +1072,6 @@ impl<'f, 'g> VariableMut<'f, 'g> {
     /// This is unsafe, as reading from this variable without
     /// writing to it will produce potential garbage values
     pub unsafe fn set_nofill(&mut self) -> error::Result<()> {
-        let _l = LOCK.lock().unwrap();
         error::checked(nc_def_var_fill(
             self.ncid,
             self.varid,
@@ -1093,7 +1085,6 @@ impl<'f, 'g> VariableMut<'f, 'g> {
     /// `endian` can take a `Endianness` value with Native being `NC_ENDIAN_NATIVE` (0),
     /// Little `NC_ENDIAN_LITTLE` (1), Big `NC_ENDIAN_BIG` (2)
     pub fn endian(&mut self, e: Endianness) -> error::Result<()> {
-        let _l = LOCK.lock().unwrap();
         let endianness = match e {
             Endianness::Native => NC_ENDIAN_NATIVE,
             Endianness::Little => NC_ENDIAN_LITTLE,

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -70,9 +70,9 @@ fn attribute_put() {
 fn open_pres_temp_4d() {
     let f = test_location().join("pres_temp_4D.nc");
 
-    let file = netcdf::File::open(&f).unwrap();
+    let file = netcdf::open(&f).unwrap();
 
-    let pres = &file.root().variable("pressure").unwrap();
+    let pres = &file.variable("pressure").unwrap().unwrap();
     assert_eq!(pres.dimensions()[0].name().unwrap(), "time");
     assert_eq!(pres.dimensions()[1].name().unwrap(), "level");
     assert_eq!(pres.dimensions()[2].name().unwrap(), "latitude");
@@ -92,10 +92,9 @@ fn open_pres_temp_4d() {
 fn global_attrs() {
     let f = test_location().join("patmosx_v05r03-preliminary_NOAA-19_asc_d20130630_c20140325.nc");
 
-    let file = netcdf::File::open(&f).unwrap();
+    let file = netcdf::open(&f).unwrap();
 
     let ch1_attr = &file
-        .root()
         .attribute("CH1_DARK_COUNT")
         .expect("netcdf error")
         .expect("Could not find attribute");
@@ -108,7 +107,6 @@ fn global_attrs() {
     }
 
     let sensor_attr = &file
-        .root()
         .attribute("sensor")
         .expect("netcdf error")
         .expect("Could not find attribute");
@@ -125,51 +123,30 @@ fn all_attr_types() {
     let u8string = "Testing utf8 with æøå and even 😀";
     {
         let f = d.path().join("all_attr_types.nc");
-        let mut file = netcdf::File::create(&f).unwrap();
+        let mut file = netcdf::create(&f).unwrap();
 
-        file.root_mut().add_attribute("attr_byte", 3 as i8).unwrap();
-        file.root_mut()
-            .add_attribute("attr_ubyte", 3 as u8)
-            .unwrap();
-        file.root_mut()
-            .add_attribute("attr_short", 3 as i16)
-            .unwrap();
-        file.root_mut()
-            .add_attribute("attr_ushort", 3 as u16)
-            .unwrap();
-        file.root_mut().add_attribute("attr_int", 3 as i32).unwrap();
-        file.root_mut()
-            .add_attribute("attr_uint", 3 as u32)
-            .unwrap();
-        file.root_mut()
-            .add_attribute("attr_int64", 3 as i64)
-            .unwrap();
-        file.root_mut()
-            .add_attribute("attr_uint64", 3 as u64)
-            .unwrap();
-        file.root_mut()
-            .add_attribute("attr_float", 3.2 as f32)
-            .unwrap();
-        file.root_mut()
-            .add_attribute("attr_double", 3.2 as f64)
-            .unwrap();
-        file.root_mut()
-            .add_attribute("attr_text", "Hello world!")
-            .unwrap();
+        file.add_attribute("attr_byte", 3 as i8).unwrap();
+        file.add_attribute("attr_ubyte", 3 as u8).unwrap();
+        file.add_attribute("attr_short", 3 as i16).unwrap();
+        file.add_attribute("attr_ushort", 3 as u16).unwrap();
+        file.add_attribute("attr_int", 3 as i32).unwrap();
+        file.add_attribute("attr_uint", 3 as u32).unwrap();
+        file.add_attribute("attr_int64", 3 as i64).unwrap();
+        file.add_attribute("attr_uint64", 3 as u64).unwrap();
+        file.add_attribute("attr_float", 3.2 as f32).unwrap();
+        file.add_attribute("attr_double", 3.2 as f64).unwrap();
+        file.add_attribute("attr_text", "Hello world!").unwrap();
 
-        file.root_mut()
-            .add_attribute("attr_text_utf8", u8string)
-            .unwrap();
+        file.add_attribute("attr_text_utf8", u8string).unwrap();
     }
 
     {
         let f = d.path().join("all_attr_types.nc");
-        let file = netcdf::File::open(&f).unwrap();
+        let file = netcdf::open(&f).unwrap();
 
         assert_eq!(
             AttrValue::Uchar(3),
-            file.root()
-                .attribute("attr_ubyte")
+            file.attribute("attr_ubyte")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -177,8 +154,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Schar(3),
-            file.root()
-                .attribute("attr_byte")
+            file.attribute("attr_byte")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -186,8 +162,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Ushort(3),
-            file.root()
-                .attribute("attr_ushort")
+            file.attribute("attr_ushort")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -195,8 +170,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Short(3),
-            file.root()
-                .attribute("attr_short")
+            file.attribute("attr_short")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -204,8 +178,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Int(3),
-            file.root()
-                .attribute("attr_int")
+            file.attribute("attr_int")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -213,8 +186,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Uint(3),
-            file.root()
-                .attribute("attr_uint")
+            file.attribute("attr_uint")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -222,8 +194,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Ulonglong(3),
-            file.root()
-                .attribute("attr_uint64")
+            file.attribute("attr_uint64")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -231,8 +202,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Longlong(3),
-            file.root()
-                .attribute("attr_int64")
+            file.attribute("attr_int64")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -240,8 +210,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Float(3.2),
-            file.root()
-                .attribute("attr_float")
+            file.attribute("attr_float")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -249,8 +218,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Double(3.2),
-            file.root()
-                .attribute("attr_double")
+            file.attribute("attr_double")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -258,8 +226,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Str("Hello world!".into()),
-            file.root()
-                .attribute("attr_text")
+            file.attribute("attr_text")
                 .unwrap()
                 .unwrap()
                 .value()
@@ -267,8 +234,7 @@ fn all_attr_types() {
         );
         assert_eq!(
             AttrValue::Str(u8string.into()),
-            file.root()
-                .attribute("attr_text_utf8")
+            file.attribute("attr_text_utf8")
                 .unwrap()
                 .unwrap()
                 .value()

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -73,10 +73,10 @@ fn open_pres_temp_4d() {
     let file = netcdf::File::open(&f).unwrap();
 
     let pres = &file.root().variable("pressure").unwrap();
-    assert_eq!(pres.dimensions()[0].name(), "time");
-    assert_eq!(pres.dimensions()[1].name(), "level");
-    assert_eq!(pres.dimensions()[2].name(), "latitude");
-    assert_eq!(pres.dimensions()[3].name(), "longitude");
+    assert_eq!(pres.dimensions()[0].name().unwrap(), "time");
+    assert_eq!(pres.dimensions()[1].name().unwrap(), "level");
+    assert_eq!(pres.dimensions()[2].name().unwrap(), "latitude");
+    assert_eq!(pres.dimensions()[3].name().unwrap(), "longitude");
 
     // test var attributes
     assert_eq!(

--- a/tests/group.rs
+++ b/tests/group.rs
@@ -1,0 +1,74 @@
+#[test]
+fn dimensions() {
+    let d = tempfile::tempdir().unwrap();
+    let path = d.path().join("dimensions.rs");
+
+    let mut file = netcdf::create(path).unwrap();
+
+    let mut group = file.add_group("group").unwrap();
+
+    group.add_dimension("a", 5).unwrap();
+    group.add_dimension("b", 6).unwrap();
+    group.add_unlimited_dimension("c").unwrap();
+
+    let dim = group.dimension("a").unwrap().unwrap();
+    assert_eq!(dim.len(), 5);
+    let dim = group.dimension("b").unwrap().unwrap();
+    assert_eq!(dim.len(), 6);
+    let dim = group.dimension("c").unwrap().unwrap();
+    assert_eq!(dim.len(), 0);
+    assert!(group.dimension("d").unwrap().is_none());
+}
+
+#[test]
+fn groups() {
+    let d = tempfile::tempdir().unwrap();
+    let path = d.path().join("groups.rs");
+    let mut file = netcdf::create(path).unwrap();
+    let mut group = file.add_group("group").unwrap();
+    group.add_group("g").unwrap();
+    group.add_group("e").unwrap();
+    group.add_group("f").unwrap();
+
+    assert_eq!(group.groups().unwrap().count(), 3);
+    assert!(group.group("w").unwrap().is_none());
+    assert!(group.group_mut("w").unwrap().is_none());
+    assert!(group.group_mut("e").unwrap().is_some());
+    assert!(group.group("f").unwrap().is_some());
+}
+
+#[test]
+fn find_variable() {
+    let d = tempfile::tempdir().unwrap();
+    let path = d.path().join("groups.rs");
+    let mut file = netcdf::create(path).unwrap();
+    let mut group = file.add_group("group").unwrap();
+
+    group.add_variable::<u8>("v", &[]).unwrap();
+    group.add_variable::<u8>("w", &[]).unwrap();
+    group.add_dimension("d", 3).unwrap();
+    group.add_variable::<u8>("z", &["d"]).unwrap();
+
+    assert_eq!(group.variables_mut().unwrap().count(), 3);
+    assert_eq!(group.variables().unwrap().count(), 3);
+
+    let v = group.variable("v").unwrap().unwrap();
+    assert_eq!(v.dimensions().iter().count(), 0);
+    assert_eq!(v.len(), 1);
+    let z = group.variable_mut("z").unwrap().unwrap();
+    assert_eq!(z.dimensions()[0].len(), 3);
+    assert_eq!(z.vartype(), netcdf_sys::NC_UBYTE);
+    assert_eq!(z.name().unwrap(), "z");
+
+    assert!(group.variable("vvvvv").unwrap().is_none());
+
+    for var in group.variables_mut().unwrap() {
+        let mut var = var.unwrap();
+        var.compression(3).unwrap();
+        if var.name().unwrap() == "z" {
+            var.chunking(&[1]).unwrap();
+        } else {
+            var.chunking(&[]).unwrap();
+        }
+    }
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -985,6 +985,7 @@ fn read_from_memory() {
     let mut v = vec![0i32; 6 * 12];
     (*file)
         .variable("data")
+        .unwrap()
         .expect("Could not find variable")
         .values_to(&mut v, None, None)
         .unwrap();
@@ -1003,7 +1004,7 @@ fn add_conflicting_dimensions() {
     let e = file.add_dimension("x", 11).unwrap_err();
     assert!(match e {
         netcdf::error::Error::AlreadyExists => true,
-        _ => false
+        _ => false,
     });
     assert_eq!(file.dimension("x").unwrap().len(), 10);
 }
@@ -1025,7 +1026,8 @@ fn add_conflicting_variables() {
         }
         e => {
             panic!(e)
-        }});
+        }
+    });
     assert_eq!(
         10,
         file.variable("x").unwrap().unwrap().dimensions()[0].len()

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -696,12 +696,12 @@ fn append() {
     assert!(file
         .root()
         .variables()
-        .find(|x| x.name() == "some_variable")
+        .find(|x| x.name().unwrap() == "some_variable")
         .is_some());
     assert!(file
         .root()
         .variables()
-        .find(|x| x.name() == "some_other_variable")
+        .find(|x| x.name().unwrap() == "some_other_variable")
         .is_some());
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -240,7 +240,7 @@ fn nc4_groups() {
     let file = netcdf::File::open(&f).unwrap();
 
     let grp1 = &file.group("grp1").expect("Could not find group");
-    assert_eq!(grp1.name(), "grp1");
+    assert_eq!(grp1.name().unwrap(), "grp1");
 
     let mut data = vec![0i32; 6 * 12];
     let var = &grp1.variable("data").unwrap();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1599,3 +1599,18 @@ fn dimension_identifiers_from_different_ncids() {
     g0.add_variable_from_identifiers::<u8>("var3", &[id, idg])
         .unwrap();
 }
+
+#[test]
+fn count_dimensions() {
+    let d = tempfile::tempdir().unwrap();
+    let mut file = netcdf::create(d.path().join("count_dimensions.rs")).unwrap();
+
+    file.add_dimension("a", 4).unwrap();
+    file.add_dimension("b", 0).unwrap();
+    file.add_dimension("c", 63).unwrap();
+    file.add_unlimited_dimension("d").unwrap();
+    file.add_unlimited_dimension("e").unwrap();
+    file.add_dimension("f", 63).unwrap();
+
+    assert_eq!(file.dimensions().unwrap().count(), 6);
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1004,9 +1004,9 @@ fn read_from_memory() {
     origfile.read_to_end(&mut bytes).unwrap();
 
     let file = netcdf::open_mem(None, &bytes).unwrap();
-    let x = &(*file).dimension("x").unwrap();
+    let x = &(*file).dimension("x").unwrap().unwrap();
     assert_eq!(x.len(), 6);
-    let y = &(*file).dimension("y").unwrap();
+    let y = &(*file).dimension("y").unwrap().unwrap();
     assert_eq!(y.len(), 12);
     let mut v = vec![0i32; 6 * 12];
     (*file)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -239,7 +239,7 @@ fn nc4_groups() {
 
     let file = netcdf::open(&f).unwrap();
 
-    let grp1 = &file.group("grp1").expect("Could not find group");
+    let grp1 = &file.group("grp1").expect("Could not find group").unwrap();
     assert_eq!(grp1.name().unwrap(), "grp1");
 
     let mut data = vec![0i32; 6 * 12];
@@ -283,6 +283,7 @@ fn create_group_dimensions() {
 
     assert_eq!(
         f.group("gp1")
+            .unwrap()
             .expect("Could not find group")
             .variable("y")
             .unwrap()
@@ -292,8 +293,10 @@ fn create_group_dimensions() {
     );
     assert_eq!(
         f.group("gp1")
+            .unwrap()
             .expect("Could not find group")
             .group("gp2")
+            .unwrap()
             .expect("Could not find group")
             .variable("y")
             .unwrap()
@@ -303,8 +306,10 @@ fn create_group_dimensions() {
     );
     assert_eq!(
         f.group("gp1")
+            .unwrap()
             .expect("Could not find group")
             .group("gp2")
+            .unwrap()
             .expect("Could not find group")
             .variable("z")
             .expect("Could not find variable")
@@ -374,7 +379,7 @@ fn def_dims_vars_attrs() {
             .unwrap();
 
         // test var attrs
-        let mut var = file.variable_mut(var_name).unwrap();
+        let mut var = file.variable_mut(var_name).unwrap().unwrap();
         var.add_attribute("varattr1", 5).unwrap();
         var.add_attribute("varattr2", "Variable string attr".to_string())
             .unwrap();
@@ -711,7 +716,7 @@ fn put_single_value() {
     {
         // re-open it in append mode
         let mut file_a = netcdf::append(&f).unwrap();
-        let var = &mut file_a.variable_mut(var_name).unwrap();
+        let var = &mut file_a.variable_mut(var_name).unwrap().unwrap();
         var.put_value(100.0f32, Some(&indices)).unwrap();
         // close it (done when `file_a` goes out of scope)
     }
@@ -747,7 +752,7 @@ fn put_values() {
     {
         // re-open it in append mode
         let mut file_a = netcdf::append(&f).unwrap();
-        let var = &mut file_a.variable_mut(var_name).unwrap();
+        let var = &mut file_a.variable_mut(var_name).unwrap().unwrap();
         let res = var.put_values(values, Some(indices), Some(len));
         assert_eq!(res.unwrap(), ());
         // close it (done when `file_a` goes out of scope)
@@ -963,7 +968,7 @@ fn set_compression_all_variables_in_a_group() {
         var.compression(9).expect("Could not set compression level");
     }
 
-    let mut var = file.variable_mut("var0").unwrap();
+    let mut var = file.variable_mut("var0").unwrap().unwrap();
     var.compression(netcdf_sys::NC_MAX_DEFLATE_LEVEL + 1)
         .unwrap_err();
 }
@@ -1248,7 +1253,7 @@ fn unlimited_in_parents() {
     }
     let mut file = netcdf::append(&path).unwrap();
 
-    let g = &mut file.group_mut("g").unwrap();
+    let g = &mut file.group_mut("g").unwrap().unwrap();
     g.add_variable::<i16>("w", &["z1"]).unwrap();
     g.add_variable::<u16>("v", &["x"]).unwrap();
 }
@@ -1266,20 +1271,25 @@ fn dimension_identifiers() {
         let g = &mut file.add_group("g").unwrap();
         let dim = &g.add_dimension("x", 5).unwrap();
         let vgid = dim.identifier();
-        let mut gg = file.group_mut("g").unwrap().add_group("g").unwrap();
+        let mut gg = file
+            .group_mut("g")
+            .unwrap()
+            .unwrap()
+            .add_group("g")
+            .unwrap();
         let dim = &gg.add_dimension("x", 7).unwrap();
         let vggid = dim.identifier();
 
         // Create variables
         file.add_variable_from_identifiers::<i8>("v_self_id", &[vrootid])
             .unwrap();
-        let mut g = file.group_mut("g").unwrap();
+        let mut g = file.group_mut("g").unwrap().unwrap();
         g.add_variable_from_identifiers::<i8>("v_root_id", &[vrootid])
             .unwrap();
         g.add_variable_from_identifiers::<i8>("v_self_id", &[vgid])
             .unwrap();
 
-        let gg = &mut g.group_mut("g").unwrap();
+        let gg = &mut g.group_mut("g").unwrap().unwrap();
         gg.add_variable_from_identifiers::<i8>("v_root_id", &[vrootid])
             .unwrap();
         gg.add_variable_from_identifiers::<i8>("v_up_id", &[vgid])
@@ -1294,6 +1304,7 @@ fn dimension_identifiers() {
     assert_eq!(
         file.group("g")
             .unwrap()
+            .unwrap()
             .variable("v_root_id")
             .unwrap()
             .len(),
@@ -1301,6 +1312,7 @@ fn dimension_identifiers() {
     );
     assert_eq!(
         file.group("g")
+            .unwrap()
             .unwrap()
             .variable("v_self_id")
             .unwrap()
@@ -1310,7 +1322,9 @@ fn dimension_identifiers() {
     assert_eq!(
         file.group("g")
             .unwrap()
+            .unwrap()
             .group("g")
+            .unwrap()
             .unwrap()
             .variable("v_self_id")
             .unwrap()
@@ -1320,7 +1334,9 @@ fn dimension_identifiers() {
     assert_eq!(
         file.group("g")
             .unwrap()
+            .unwrap()
             .group("g")
+            .unwrap()
             .unwrap()
             .variable("v_up_id")
             .unwrap()
@@ -1330,7 +1346,9 @@ fn dimension_identifiers() {
     assert_eq!(
         file.group("g")
             .unwrap()
+            .unwrap()
             .group("g")
+            .unwrap()
             .unwrap()
             .variable("v_root_id")
             .unwrap()

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -994,17 +994,16 @@ fn read_from_memory() {
 }
 
 #[test]
-fn add_confliciting_dimensions() {
+fn add_conflicting_dimensions() {
     let d = tempfile::tempdir().unwrap();
 
     let mut file = netcdf::create(d.path().join("conflict_dim.nc")).unwrap();
 
     file.add_dimension("x", 10).unwrap();
     let e = file.add_dimension("x", 11).unwrap_err();
-    assert!(if let netcdf::error::Error::AlreadyExists(x) = e {
-        x == "dimension x"
-    } else {
-        false
+    assert!(match e {
+        netcdf::error::Error::AlreadyExists => true,
+        _ => false
     });
     assert_eq!(file.dimension("x").unwrap().len(), 10);
 }
@@ -1020,11 +1019,13 @@ fn add_conflicting_variables() {
     file.add_variable::<i32>("x", &["x"]).unwrap();
 
     let e = file.add_variable::<f32>("x", &["y"]).unwrap_err();
-    assert!(if let netcdf::error::Error::AlreadyExists(x) = e {
-        x == "variable"
-    } else {
-        false
-    });
+    assert!(match e {
+        netcdf::error::Error::AlreadyExists => {
+            true
+        }
+        e => {
+            panic!(e)
+        }});
     assert_eq!(
         10,
         file.variable("x").unwrap().unwrap().dimensions()[0].len()

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1292,14 +1292,12 @@ fn dimension_identifiers() {
         let g = &mut file.add_group("g").unwrap();
         let dim = &g.add_dimension("x", 5).unwrap();
         let vgid = dim.identifier();
-        let mut gg = file
-            .group_mut("g")
-            .unwrap()
-            .unwrap()
-            .add_group("g")
-            .unwrap();
-        let dim = &gg.add_dimension("x", 7).unwrap();
-        let vggid = dim.identifier();
+        let vggid = {
+            let mut g = file.group_mut("g").unwrap().unwrap();
+            let mut gg = g.add_group("g").unwrap();
+            let dim = &gg.add_dimension("x", 7).unwrap();
+            dim.identifier()
+        };
 
         // Create variables
         file.add_variable_from_identifiers::<i8>("v_self_id", &[vrootid])


### PR DESCRIPTION
This is a complete revamp of ownership and caching of the file. The rust side is now not reading more than strictly necessary, and instead goes through `netcdf-c`. The ownership is now determined by `PhantomData`, which prevents early dropping of the `File`.

Multiple `VariableMut` can be held simultaneously (from different groups or from `variables_mut`), with the `PhantomData` preventing data races. This change should decrease memory usage of the library, especially when not reading all attributes of a file, as only `netCDF-c` holds the metadata (fixes #44).

The library might be a bit more annoying to use, as almost all operations can fail in the `netcdf-c` layer. Some unwrapping can probably be done on the library side, so application users can deal with an easier API. I am leaving this as a future exercise.